### PR TITLE
chore: rm indent cmds from pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,18 +49,6 @@
         "url": "https://github.com/Unibeautify/vscode/issues"
     },
     "homepage": "https://github.com/Unibeautify/vscode#readme",
-    "contributes": {
-        "commands": [
-            {
-                "title": "Beautify File",
-                "command": "Unibeautify.beautifyFile"
-            },
-            {
-                "title": "Beautify Selection",
-                "command": "Unibeautify.beautifySelection"
-            }
-        ]
-    },
     "badges": [
         {
             "url": "https://badges.greenkeeper.io/Unibeautify/vscode.svg",


### PR DESCRIPTION
These removed commands are now integrated with VSCode itself.

 ~Maybe there are some few extra docs where these guys are still in need to be erased, I will search for them.~ I found nothing more.