### PR TITLE
Include period in file extension when beautifying

### DIFF
--- a/src/EditProvider.ts
+++ b/src/EditProvider.ts
@@ -104,7 +104,7 @@ export class EditProvider
   ): string | undefined {
     const { fileName } = document;
     if (fileName) {
-      return extname(fileName).slice(1);
+      return `.${extname(fileName).slice(1)}`;
     }
     return undefined;
   }


### PR DESCRIPTION
* Changes `fileExtensionForDocument` method to include the period in the file extension being returned (`.html` instead of `html`).

Closes #94.  Will open a separate PR in Unibeautify for the other half of the fix in #94.  But this alone will at least allow ColdFusion files to be formatted.