### PR TITLE
Update js-beautify dependency to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4875,15 +4875,22 @@
             }
         },
         "js-beautify": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
-            "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.11.0.tgz",
+            "integrity": "sha512-a26B+Cx7USQGSWnz9YxgJNMmML/QG2nqIaL7VVYPCXbqiKz8PN0waSNvroMtvAK6tY7g/wPdNWGEP+JTNIBr6A==",
             "requires": {
                 "config-chain": "^1.1.12",
                 "editorconfig": "^0.15.3",
                 "glob": "^7.1.3",
-                "mkdirp": "~0.5.1",
-                "nopt": "~4.0.1"
+                "mkdirp": "~1.0.3",
+                "nopt": "^4.0.3"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+                }
             }
         },
         "js-tokens": {
@@ -5507,9 +5514,9 @@
             "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
         },
         "nopt": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
             "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "csscomb": "^4.3.0",
         "diff": "^4.0.0",
         "eslint": "^4.19.1",
-        "js-beautify": "^1.10.2",
+        "js-beautify": "^1.11.0",
         "prettier": "^1.18.2",
         "prettydiff2": "^2.2.8",
         "stylelint": "^9.7.1",


### PR DESCRIPTION
Update js-beautify from 1.10.2 to 1.11.0

Adds support for several new JS proposals, see https://github.com/beautify-web/js-beautify/blob/master/CHANGELOG.md.

